### PR TITLE
Switch to Web Test Runner and webpack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,10 +124,6 @@ var thisPort = process.env.PORT || 3333
           livereload: true
         },
         files: ['modules/**/*.js', 'index.html', 'modules/**/*.js', 'router.js', 'main.js', 'app.js']
-      },
-        karma: {
-        files: ['test/jasmine/specs/**/*.js', 'test/runner.js','test/jasmine/specs/**/*.html'],
-        tasks: ['default'] //NOTE the :run flag
       }
     },
 
@@ -142,81 +138,7 @@ var thisPort = process.env.PORT || 3333
       }
     },
 
-    // Unit testing is provided by Karma.  Change the two commented locations
-    // below to either: mocha, jasmine, or qunit.
-    karma: {
-      options: {
-        basePath: process.cwd(),
-        singleRun: true,
-        captureTimeout: 7000,
-        autoWatch: true,
-
-        reporters: ["progress", "coverage"],
-        browsers: ["PhantomJS"],
-
-        // Change this to the framework you want to use.
-        frameworks: ["jasmine"],
-
-        plugins: [
-          "karma-jasmine",
-          "karma-mocha",
-          "karma-qunit",
-          "karma-phantomjs-launcher",
-          "karma-coverage"
-        ],
-
-        preprocessors: {
-          "app/**/*.js": "coverage"
-        },
-
-        coverageReporter: {
-          type: "lcov",
-          dir: "test/coverage"
-        },
-
-        files: [
-          // You can optionally remove this or swap out for a different expect.
-          "vendor/bower/chai/chai.js",
-          "vendor/bower/requirejs/require.js",
-          "test/runner.js",
-
-          {
-            pattern: "app/**/*.*",
-            included: false
-          },
-          // Derives test framework from Karma configuration.
-          {
-            pattern: "test/<%= karma.options.frameworks[0] %>/**/*.spec.js",
-            included: false
-          },
-          {
-            pattern: "vendor/**/*.js",
-            included: false
-          }
-        ]
-      },
-
-      // This creates a server that will automatically run your tests when you
-      // save a file and display results in the terminal.
-      daemon: {
-        options: {
-          singleRun: false
-        }
-      },
-
-      // This is useful for running the tests just once.
-      run: {
-        options: {
-          singleRun: true
-        }
-      }
-    },
-
-    coveralls: {
-      options: {
-        coverage_dir: "test/coverage/PhantomJS 1.9.2 (Linux)/"
-      }
-    }
+    // Unit testing is handled by Web Test Runner.
   });
 
   grunt.loadNpmTasks('grunt-contrib-watch');
@@ -228,8 +150,6 @@ var thisPort = process.env.PORT || 3333
   grunt.loadNpmTasks("grunt-contrib-compress");
 
   // Third-party tasks.
-  grunt.loadNpmTasks("grunt-karma");
-  grunt.loadNpmTasks("grunt-karma-coveralls");
   grunt.loadNpmTasks("grunt-processhtml");
 
   // Grunt BBB tasks.
@@ -238,7 +158,8 @@ var thisPort = process.env.PORT || 3333
   grunt.loadNpmTasks("grunt-bbb-styles");
 
   // Create an aliased test task.
-  grunt.registerTask("test", ["karma:run"]);
+  // Tests are now run with Web Test Runner
+  grunt.registerTask("test", []);
   // When running the default Grunt command, just lint the code.
   grunt.registerTask("default", [
     "clean",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WASD controls, press the space bar to do the action that the level says you shou
 
 ## Local Development
 
-1. Install dependencies and build the bundle:
+1. Install dependencies and build the bundle using webpack:
    ```bash
    npm install
    npm run build
@@ -33,3 +33,11 @@ Then open [http://localhost:3333](http://localhost:3333) in your browser.
 
 Use the **Mute** button (or press **M**) to toggle audio. The preference
 persists across sessions.
+
+### Running Tests
+
+Run the automated tests with Web Test Runner:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "bbb": "~0.2.0",
-    "karma": "~0.12.0",
+    "@web/test-runner": "^0.16.0",
+    "@web/test-runner-jasmine": "^0.9.1",
+    "@web/test-runner-playwright": "^0.10.2",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.4",
     "grunt-contrib-jshint": "~0.6.0",
@@ -11,13 +13,6 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-compress": "~0.5.2",
     "grunt-processhtml": "~0.2.0",
-    "grunt-karma": "~0.6.2",
-    "grunt-karma-coveralls": "~2.0.2",
-    "karma-jasmine": "~0.1.0",
-    "karma-mocha": "~0.1.0",
-    "karma-qunit": "~0.1.0",
-    "karma-phantomjs-launcher": "~0.1.0",
-    "karma-coverage": "~0.1.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-cli": "~0.1.13"
   },
@@ -27,9 +22,9 @@
     "coveralls": "*"
   },
   "scripts": {
-    "test": "grunt test coveralls",
+    "test": "web-test-runner --config web-test-runner.config.js",
     "start": "node server.js",
-    "build": "webpack"
+    "build": "webpack --mode=production"
   },
   "name": "dark-room",
   "version": "0.1.0",

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,0 +1,9 @@
+import { playwrightLauncher } from '@web/test-runner-playwright';
+import { jasmine } from '@web/test-runner-jasmine';
+
+export default {
+  files: 'test/jasmine/specs/**/*.spec.js',
+  nodeResolve: true,
+  browsers: [playwrightLauncher({ product: 'chromium' })],
+  plugins: [jasmine()],
+};


### PR DESCRIPTION
## Summary
- switch testing to Web Test Runner
- simplify Gruntfile by removing Karma tasks
- add Web Test Runner config
- document new commands in README
- use webpack for the build script

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d288b2c5c832885ac1d9a5bfd4c19