### PR TITLE
Modernize modules with pointer lock and puzzle

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,15 +1,8 @@
-define(function(require, exports, module) {
-  "use strict";
+import 'helvetiker';
 
-  // External dependencies.
-  var _ = require("underscore");
-  var $ = require("jquery");
-  var Backbone = require("backbone");
-  var helvetiker=require('helvetiker')
-  // Alias the module for easier identification.
-  var app = module.exports;
+const app = {};
 
+// The root path to run the application through.
+app.root = "/";
 
-  // The root path to run the application through.
-  app.root = "/";
-});
+export default app;

--- a/app/main.js
+++ b/app/main.js
@@ -1,17 +1,17 @@
-define(function(require){
-  'use strict';
-  var app = require('app');
-  var Router = require('router');
-  var audio = require('audioToggle');
+import Backbone from 'backbone';
+import app from './app.js';
+import Router from './router.js';
+import audio from './audioToggle.js';
 
-  app.router = new Router();
+app.router = new Router();
 
-  Backbone.history.start({
-    pushState: false,
-    root: app.root
-  });
-
-  if(audio && audio.initAudioToggle){
-    audio.initAudioToggle();
-  }
+Backbone.history.start({
+  pushState: false,
+  root: app.root
 });
+
+if (audio && audio.initAudioToggle) {
+  audio.initAudioToggle();
+}
+
+export default app;

--- a/app/modules/controllers/controllers.first_person.js
+++ b/app/modules/controllers/controllers.first_person.js
@@ -1,14 +1,38 @@
-define(function(require, exports, module) {
-	"use strict";
+import $ from 'jquery';
+import _ from 'underscore';
+import Backbone from 'backbone';
+import app from 'app';
+import THREEx from 'threex';
+import story from 'modules/story/story.main';
+import createMagicSquare from 'modules/puzzles/magic_square';
 
-	var $ = require("jquery");
-	var _ = require("underscore");
-	var Backbone = require("backbone");
-	var app = require("app");
-	var THREEx = require('threex');
-	var keyboard = new THREEx.KeyboardState();
+const keyboard = new THREEx.KeyboardState();
 
-	var  story = require('modules/story/story.main');
+document.addEventListener('keydown', (e) => {
+  if (e.code === 'KeyP') {
+    document.body.requestPointerLock();
+  }
+  if (e.code === 'KeyO') {
+    createMagicSquare(() => {
+      console.log('Magic square solved');
+    });
+  }
+});
+
+document.addEventListener('pointerlockchange', () => {
+  const hint = document.getElementById('pointerHint');
+  if (hint) {
+    hint.style.display =
+      document.pointerLockElement === document.body ? 'none' : 'block';
+  }
+});
+
+document.addEventListener('mousemove', (e) => {
+  if (document.pointerLockElement === document.body && keyboard.player) {
+    keyboard.player.rotation.y -= e.movementX * 0.002;
+    keyboard.player.rotation.x -= e.movementY * 0.002;
+  }
+});
 
  
 
@@ -266,5 +290,4 @@ for (var vertexIndex = 0; vertexIndex < _mesh.geometry.vertices.length; vertexIn
 	}
 
 
-	module.exports = keyboard;
-});
+export default keyboard;

--- a/app/modules/puzzles/magic_square.js
+++ b/app/modules/puzzles/magic_square.js
@@ -1,0 +1,50 @@
+export default function createMagicSquare(onSolved) {
+  const target = [
+    [8, 1, 6],
+    [3, 5, 7],
+    [4, 9, 2]
+  ];
+  const state = [
+    ['', '', ''],
+    ['', '', ''],
+    ['', '', '']
+  ];
+
+  const container = document.createElement('div');
+  container.id = 'magicSquare';
+
+  function check() {
+    for (let i = 0; i < 3; i++) {
+      for (let j = 0; j < 3; j++) {
+        if (state[i][j] !== target[i][j]) {
+          return;
+        }
+      }
+    }
+    container.classList.add('solved');
+    if (typeof onSolved === 'function') onSolved();
+    setTimeout(() => container.remove(), 1000);
+  }
+
+  for (let i = 0; i < 3; i++) {
+    for (let j = 0; j < 3; j++) {
+      const cell = document.createElement('div');
+      cell.className = 'magic-cell';
+      cell.dataset.row = i;
+      cell.dataset.col = j;
+      cell.textContent = '';
+      cell.addEventListener('click', () => {
+        const val = prompt('Enter number 1-9');
+        if (!val) return;
+        const n = parseInt(val, 10);
+        cell.textContent = n;
+        state[i][j] = n;
+        check();
+      });
+      container.appendChild(cell);
+    }
+  }
+
+  document.body.appendChild(container);
+}
+

--- a/app/router.js
+++ b/app/router.js
@@ -1,12 +1,20 @@
-define(function(require, exports, module) {
-  "use strict";
+import Backbone from 'backbone';
+import * as THREE from 'three';
+import cameraMain from 'modules/cameras/cameras.main';
+import darkroom from 'modules/levels/levels.darkroom';
+import cameraBurningBox from 'modules/cameras/cameras.burningbox';
+import burningbox from 'modules/levels/levels.burningbox';
+import cameraDinnerParty from 'modules/cameras/cameras.dinner_party';
+import dinnerParty from 'modules/levels/levels.dinner_party';
+import cameraLizards from 'modules/cameras/cameras.procession_of_lizards';
+import processionOfLizards from 'modules/levels/levels.procession_of_lizards';
+import cameraTrain from 'modules/cameras/cameras.train';
+import train from 'modules/levels/levels.train';
+import rendererMain from 'modules/renderers/renderers.main';
+import keyboard from 'modules/controllers/controllers.first_person';
+import story from 'modules/story/story.main';
 
-
-  // External dependencies.
-  var Backbone = require("backbone");
-  var THREE = require('three')
-  // Defining the application router.
-  module.exports = Backbone.Router.extend({
+export default Backbone.Router.extend({
     routes: {
       "": "index"
     },
@@ -68,15 +76,10 @@ define(function(require, exports, module) {
 
         //camera, scene
 
-        var cameraMain = require('modules/cameras/cameras.main');
         currentScene.set('cameraMain', cameraMain);
-        var darkroom = require('modules/levels/levels.darkroom');
         currentScene.set('level', darkroom);
-        var cameraBurningBox = require('modules/cameras/cameras.burningbox');
         cameraBurningBox.position.set(2684,240,248);
         currentScene.set('cameraBurningBox', cameraBurningBox)
-        var burningbox = require('modules/levels/levels.burningbox');
-
         currentScene.set('burningbox', burningbox)
                 darkroom.objectsToAnimate.push(cameraBurningBox,burningbox.screenCamera)
         console.log('cameraBurningBox',cameraBurningBox)
@@ -84,19 +87,13 @@ define(function(require, exports, module) {
   
 
 
-        var cameraDinnerParty = require('modules/cameras/cameras.dinner_party');
         currentScene.set('cameraDinnerParty', cameraDinnerParty)
-        var dinnerParty = require('modules/levels/levels.dinner_party');
         currentScene.set('dinnerParty', dinnerParty)
 
-        var cameraLizards = require('modules/cameras/cameras.procession_of_lizards');
         currentScene.set('cameraLizards', cameraLizards)
-        var processionOfLizards = require('modules/levels/levels.procession_of_lizards');
         currentScene.set('processionOfLizards', processionOfLizards)
 
-        var cameraTrain = require('modules/cameras/cameras.train');
         currentScene.set('cameraTrain', cameraTrain)
-        var train = require('modules/levels/levels.train');
         currentScene.set('train', train)
 
         darkroom.add(cameraBurningBox);
@@ -130,7 +127,7 @@ define(function(require, exports, module) {
 
 
 
-        var renderer = require('modules/renderers/renderers.main');
+        var renderer = rendererMain;
         renderer.autoClear = false;
         renderer.setSize(window.innerWidth , window.innerHeight)
         currentScene.set('renderer', renderer);
@@ -139,7 +136,6 @@ define(function(require, exports, module) {
        $('#statusHolder').show()
 
 
-        var keyboard = require('modules/controllers/controllers.first_person');
         keyboard.player = darkroom.player;
 
         var detectGeometry = new THREE.CubeGeometry(800, 800, 800, 100, 100, 100);
@@ -153,8 +149,6 @@ define(function(require, exports, module) {
         keyboard.detectMesh = detectMesh;
 
         currentScene.set('keyboard', keyboard);
-
-        var story = require('modules/story/story.main');
 
         story.makeTheStory();
 
@@ -195,9 +189,7 @@ define(function(require, exports, module) {
 
       init();
       animate();
-      var keyboard = require('modules/controllers/controllers.first_person');
-        keyboard.enterLevel(27)
+      keyboard.enterLevel(27)
 
     }
   });
-});

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -50,6 +50,57 @@ margin-top:200px;
 	height:100%;
 	width:100%;
 	text-align:center;
-	font-size:48pt;
+        font-size:48pt;
 
+}
+
+#crosshair {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 24px;
+  color: white;
+  pointer-events: none;
+}
+
+#pointerHint {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: white;
+  display: none;
+}
+
+#magicSquare {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: grid;
+  grid-template-columns: repeat(3, 50px);
+  grid-template-rows: repeat(3, 50px);
+  gap: 5px;
+}
+
+.magic-cell {
+  width: 50px;
+  height: 50px;
+  background: #222;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+#magicSquare.solved {
+  animation: fadeOut 1s forwards;
+}
+
+@keyframes fadeOut {
+  to {
+    opacity: 0;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
   <audio id="bgMusic" src="/app/sound/darkRoomSONG.mp3" autoplay loop></audio>
   <audio id="vocals" src="/app/sound/vocal0.mp3" autoplay loop></audio>
   <button id="audioToggle">Mute</button>
+  <div id="pointerHint">Press P to lock pointer</div>
+  <div id="crosshair">+</div>
   <!-- Application container. -->
     <main role="main" id="main"></main>
   <div id="loader">

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "express": "^4.13.1",
     "jquery": "^3.7.1",
     "underscore": "^1.13.6",
-    "backbone": "^1.5.0"
+    "backbone": "^1.5.0",
+    "three": "^0.158.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,11 +11,12 @@ module.exports = {
       jquery: 'jquery',
       underscore: 'underscore',
       backbone: 'backbone',
-      three: path.resolve(__dirname, 'vendor/three'),
+      three: 'three',
       threex: path.resolve(__dirname, 'vendor/THREEx.KeyboardState'),
       _typeface_js: path.resolve(__dirname, 'vendor/typeface-0.15'),
       helvetiker: path.resolve(__dirname, 'vendor/helvetiker_regular.typeface.js'),
-      audioToggle: path.resolve(__dirname, 'app/audioToggle')
+      audioToggle: path.resolve(__dirname, 'app/audioToggle'),
+      modules: path.resolve(__dirname, 'app/modules')
     }
   },
   mode: 'production'


### PR DESCRIPTION
## Summary
- modernize key modules to ES module syntax
- pull `three` from npm and update webpack aliases
- implement pointer lock controls and crosshair UI
- add a small Magic Square puzzle

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d2b6586cc832897ff57b68892902b