### PR TITLE
Implement dynamic loading, progress overlay, offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ Run the automated tests with Web Test Runner:
 ```bash
 npm test
 ```
+
+### Offline Play
+
+The game includes a service worker that caches key assets for offline use. After
+loading the site once while online, you can revisit without a network
+connection and it will continue to work.

--- a/app/levelLoader.js
+++ b/app/levelLoader.js
@@ -1,0 +1,35 @@
+const loaded = {};
+
+const loaders = {
+  burningbox: () => Promise.all([
+    import(/* webpackChunkName: "burningbox" */ './modules/levels/levels.burningbox.js'),
+    import(/* webpackChunkName: "camera-burningbox" */ './modules/cameras/cameras.burningbox.js')
+  ]),
+  dinner_party: () => Promise.all([
+    import(/* webpackChunkName: "dinner_party" */ './modules/levels/levels.dinner_party.js'),
+    import(/* webpackChunkName: "camera-dinner_party" */ './modules/cameras/cameras.dinner_party.js')
+  ]),
+  procession_of_lizards: () => Promise.all([
+    import(/* webpackChunkName: "lizards" */ './modules/levels/levels.procession_of_lizards.js'),
+    import(/* webpackChunkName: "camera-lizards" */ './modules/cameras/cameras.procession_of_lizards.js')
+  ]),
+  train: () => Promise.all([
+    import(/* webpackChunkName: "train" */ './modules/levels/levels.train.js'),
+    import(/* webpackChunkName: "camera-train" */ './modules/cameras/cameras.train.js')
+  ])
+};
+
+export async function loadLevel(name) {
+  if (loaded[name]) return loaded[name];
+  const loader = loaders[name];
+  if (!loader) throw new Error(`Unknown level ${name}`);
+  const [levelMod, cameraMod] = await loader();
+  const level = levelMod.default || levelMod;
+  const camera = cameraMod.default || cameraMod;
+  loaded[name] = { level, camera };
+  return loaded[name];
+}
+
+export function getLoadedLevel(name) {
+  return loaded[name];
+}

--- a/app/main.js
+++ b/app/main.js
@@ -2,6 +2,7 @@ import Backbone from 'backbone';
 import app from './app.js';
 import Router from './router.js';
 import { initAudioToggle } from './audioToggle.js';
+import { initProgressOverlay } from './progressOverlay.js';
 
 app.router = new Router();
 
@@ -11,5 +12,6 @@ Backbone.history.start({
 });
 
 initAudioToggle();
+initProgressOverlay();
 
 export default app;

--- a/app/modules/controllers/controllers.first_person.js
+++ b/app/modules/controllers/controllers.first_person.js
@@ -110,8 +110,9 @@ keyboard.rotations.train={	x: 0, y: -0.10000000000000063, z: 0}
 	keyboard.player.rotation.z=rotation.z;	
 	}
 	}
-        keyboard.enterLevel=function(id){
+        keyboard.enterLevel=async function(id){
                 markLevelVisited(id);
+                await app.router.loadLevelById(id);
                 if(id==="darkroom"){
 $('#goalText').text('');
 keyboard.relocatePlayer(keyboard.locations.darkroom)

--- a/app/progress.js
+++ b/app/progress.js
@@ -27,6 +27,11 @@ export function getProgress() {
   return progress;
 }
 
+export function resetProgress() {
+  progress = { levels: {}, items: {}, puzzleSolved: false };
+  save();
+}
+
 function save() {
   localStorage.setItem('progress', JSON.stringify(progress));
 }

--- a/app/progressOverlay.js
+++ b/app/progressOverlay.js
@@ -1,0 +1,39 @@
+import { getProgress, resetProgress } from './progress.js';
+
+export function initProgressOverlay() {
+  const overlay = document.createElement('div');
+  overlay.id = 'progressOverlay';
+  overlay.innerHTML = `
+    <h2>Progress</h2>
+    <div>Visited Levels:</div>
+    <ul id="visitedList"></ul>
+    <div>Items:</div>
+    <ul id="itemsList"></ul>
+    <div id="puzzleStatus"></div>
+    <button id="resetProgress">Reset Progress</button>
+  `;
+  document.body.appendChild(overlay);
+
+  function update() {
+    const prog = getProgress();
+    const visited = overlay.querySelector('#visitedList');
+    visited.innerHTML = Object.keys(prog.levels).map(l => `<li>${l}</li>`).join('') || '<li>None</li>';
+    const items = overlay.querySelector('#itemsList');
+    items.innerHTML = Object.keys(prog.items).map(i => `<li>${i}</li>`).join('') || '<li>None</li>';
+    overlay.querySelector('#puzzleStatus').textContent = prog.puzzleSolved ? 'Puzzle solved!' : 'Puzzle not solved';
+  }
+
+  overlay.querySelector('#resetProgress').addEventListener('click', () => {
+    resetProgress();
+    update();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.code === 'KeyP') {
+      overlay.style.display = overlay.style.display === 'block' ? 'none' : 'block';
+      if (overlay.style.display === 'block') update();
+    }
+  });
+}
+
+export default { initProgressOverlay };

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -104,3 +104,21 @@ margin-top:200px;
     opacity: 0;
   }
 }
+
+#progressOverlay {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0,0,0,0.8);
+  color: white;
+  padding: 10px;
+  z-index: 1000;
+  display: none;
+}
+#progressOverlay ul {
+  list-style: none;
+  padding-left: 0;
+}
+#progressOverlay button {
+  margin-top: 5px;
+}

--- a/index.html
+++ b/index.html
@@ -41,6 +41,13 @@
 
   <!-- Application source. -->
   <script src="/dist/bundle.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function() {
+        navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
+  </script>
  
 
   

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,21 @@
+const CACHE_NAME = 'darkroom-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/dist/bundle.js',
+  '/app/styles/index.css',
+  '/app/sound/darkRoomSONG.mp3',
+  '/app/sound/vocal0.mp3'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});

--- a/test/jasmine/specs/progress/progress.spec.js
+++ b/test/jasmine/specs/progress/progress.spec.js
@@ -1,0 +1,22 @@
+define(function(require) {
+  'use strict';
+  var progress = require('../../../../app/progress.js');
+
+  describe('progress module', function() {
+    afterEach(function() {
+      progress.resetProgress();
+    });
+
+    it('stores visited levels', function() {
+      progress.resetProgress();
+      progress.markLevelVisited('foo');
+      expect(progress.getProgress().levels.foo).toBe(true);
+    });
+
+    it('clears progress on reset', function() {
+      progress.markItemCollected('item');
+      progress.resetProgress();
+      expect(progress.getProgress().items.item).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add lazy loading helper for levels
- implement progress overlay with reset functionality
- expose resetProgress API
- initialize overlay in app
- dynamically load levels when entering
- add service worker and register it
- style progress overlay
- add basic progress tests
- document offline play

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d50a2e948832895b051720bdbe388