### PR TITLE
Enhance UX with responsive renderer and puzzle leaderboard

### DIFF
--- a/app/modules/puzzles/magic_square.js
+++ b/app/modules/puzzles/magic_square.js
@@ -1,4 +1,7 @@
+import { startPuzzle } from '../../progress';
+
 export default function createMagicSquare(onSolved) {
+  startPuzzle();
   const target = [
     [8, 1, 6],
     [3, 5, 7],

--- a/app/progress.ts
+++ b/app/progress.ts
@@ -2,6 +2,8 @@ export interface ProgressState {
   levels: Record<string, boolean>;
   items: Record<string, boolean>;
   puzzleSolved: boolean;
+  puzzleTimes: number[];
+  currentAttemptStart?: number;
 }
 
 export function loadProgress(): ProgressState {
@@ -9,14 +11,20 @@ export function loadProgress(): ProgressState {
     return JSON.parse(localStorage.getItem('progress') || 'null') || {
       levels: {},
       items: {},
-      puzzleSolved: false
+      puzzleSolved: false,
+      puzzleTimes: []
     };
   } catch (e) {
-    return { levels: {}, items: {}, puzzleSolved: false };
+    return { levels: {}, items: {}, puzzleSolved: false, puzzleTimes: [] };
   }
 }
 
 let progress: ProgressState = loadProgress();
+
+export function startPuzzle(): void {
+  progress.currentAttemptStart = Date.now();
+  save();
+}
 
 export function markLevelVisited(id: string): void {
   progress.levels[id] = true;
@@ -30,7 +38,23 @@ export function markItemCollected(name: string): void {
 
 export function markPuzzleSolved(): void {
   progress.puzzleSolved = true;
+  if (progress.currentAttemptStart) {
+    progress.puzzleTimes.push(Date.now() - progress.currentAttemptStart);
+    progress.currentAttemptStart = undefined;
+  }
   save();
+}
+
+export function resetPuzzleTimes(): void {
+  progress.puzzleTimes = [];
+  progress.currentAttemptStart = undefined;
+  progress.puzzleSolved = false;
+  save();
+}
+
+export function getBestPuzzleTime(): number | null {
+  if (!progress.puzzleTimes.length) return null;
+  return Math.min(...progress.puzzleTimes);
 }
 
 export function getProgress(): ProgressState {
@@ -38,7 +62,7 @@ export function getProgress(): ProgressState {
 }
 
 export function resetProgress(): void {
-  progress = { levels: {}, items: {}, puzzleSolved: false };
+  progress = { levels: {}, items: {}, puzzleSolved: false, puzzleTimes: [] };
   save();
 }
 

--- a/app/progressOverlay.js
+++ b/app/progressOverlay.js
@@ -1,4 +1,4 @@
-import { getProgress, resetProgress } from './progress';
+import { getProgress, resetProgress, getBestPuzzleTime, resetPuzzleTimes } from './progress';
 
 export function initProgressOverlay() {
   const overlay = document.createElement('div');
@@ -10,6 +10,8 @@ export function initProgressOverlay() {
     <div>Items:</div>
     <ul id="itemsList"></ul>
     <div id="puzzleStatus"></div>
+    <div id="bestTime"></div>
+    <button id="resetPuzzleTimes">Reset Puzzle Times</button>
     <button id="resetProgress">Reset Progress</button>
   `;
   document.body.appendChild(overlay);
@@ -21,10 +23,17 @@ export function initProgressOverlay() {
     const items = overlay.querySelector('#itemsList');
     items.innerHTML = Object.keys(prog.items).map(i => `<li>${i}</li>`).join('') || '<li>None</li>';
     overlay.querySelector('#puzzleStatus').textContent = prog.puzzleSolved ? 'Puzzle solved!' : 'Puzzle not solved';
+    const best = getBestPuzzleTime();
+    overlay.querySelector('#bestTime').textContent = best != null ? `Fastest Time: ${(best/1000).toFixed(1)}s` : 'No puzzle times yet';
   }
 
   overlay.querySelector('#resetProgress').addEventListener('click', () => {
     resetProgress();
+    update();
+  });
+
+  overlay.querySelector('#resetPuzzleTimes').addEventListener('click', () => {
+    resetPuzzleTimes();
     update();
   });
 

--- a/app/router.js
+++ b/app/router.js
@@ -2,7 +2,7 @@ import Backbone from 'backbone';
 import * as THREE from 'three';
 import cameraMain from 'modules/cameras/cameras.main';
 import darkroom from 'modules/levels/levels.darkroom';
-import { loadLevel, getLoadedLevel } from './levelLoader.js';
+import { loadLevel, getLoadedLevel, prefetchLevel } from './levelLoader.js';
 import rendererMain from 'modules/renderers/renderers.main';
 import keyboard from 'modules/controllers/controllers.first_person';
 import story from 'modules/story/story.main';
@@ -125,6 +125,11 @@ export default Backbone.Router.extend({
         var renderer = rendererMain;
         renderer.autoClear = false;
         renderer.setSize(window.innerWidth , window.innerHeight)
+        window.addEventListener('resize', () => {
+          renderer.setSize(window.innerWidth, window.innerHeight);
+          cameraMain.aspect = window.innerWidth / window.innerHeight;
+          cameraMain.updateProjectionMatrix();
+        });
         currentScene.set('renderer', renderer);
         $('#loader').hide();
         document.body.appendChild(renderer.domElement);
@@ -175,7 +180,10 @@ export default Backbone.Router.extend({
         keyboard.addToCollideableObjects(divider2)
         keyboard.addToCollideableObjects(divider3)
         keyboard.addToCollideableObjects(divider4)
-     
+
+        const prefetchNames = ['burningbox','dinner_party','train','procession_of_lizards'];
+        prefetchNames.forEach(name => prefetchLevel(name));
+
         // story.makeStoryElement(2);
         // story.makeStoryElement(3);
         // story.makeStoryElement(4);

--- a/service-worker.js
+++ b/service-worker.js
@@ -8,7 +8,15 @@ const ASSETS = [
   '/dist/bundle.js',
   '/app/styles/index.css',
   '/app/sound/darkRoomSONG.mp3',
-  '/app/sound/vocal0.mp3'
+  '/app/sound/vocal0.mp3',
+  '/app/modules/levels/levels.burningbox.js',
+  '/app/modules/cameras/cameras.burningbox.js',
+  '/app/modules/levels/levels.dinner_party.js',
+  '/app/modules/cameras/cameras.dinner_party.js',
+  '/app/modules/levels/levels.procession_of_lizards.js',
+  '/app/modules/cameras/cameras.procession_of_lizards.js',
+  '/app/modules/levels/levels.train.js',
+  '/app/modules/cameras/cameras.train.js'
 ];
 
 self.addEventListener('install', event => {
@@ -33,6 +41,14 @@ self.addEventListener('fetch', event => {
     return;
   }
   event.respondWith(
-    caches.match(event.request).then(resp => resp || fetch(event.request))
+    caches.match(event.request).then(resp => {
+      if (resp) return resp;
+      return fetch(event.request).then(netResp => {
+        if (event.request.url.includes('/modules/')) {
+          caches.open(CACHE_NAME).then(c => c.put(event.request, netResp.clone()));
+        }
+        return netResp;
+      });
+    })
   );
 });

--- a/test/jasmine/specs/progress/progress.spec.js
+++ b/test/jasmine/specs/progress/progress.spec.js
@@ -13,10 +13,22 @@ define(function(require) {
       expect(progress.getProgress().levels.foo).toBe(true);
     });
 
-    it('clears progress on reset', function() {
-      progress.markItemCollected('item');
-      progress.resetProgress();
-      expect(progress.getProgress().items.item).toBeUndefined();
-    });
+  it('clears progress on reset', function() {
+    progress.markItemCollected('item');
+    progress.resetProgress();
+    expect(progress.getProgress().items.item).toBeUndefined();
+  });
+
+  it('records puzzle completion time', function() {
+    progress.resetProgress();
+    progress.startPuzzle();
+    jasmine.clock().install();
+    jasmine.clock().tick(2000);
+    progress.markPuzzleSolved();
+    jasmine.clock().uninstall();
+    expect(progress.getProgress().puzzleTimes.length).toBe(1);
+    expect(progress.getProgress().puzzleTimes[0]).toBe(2000);
+    expect(progress.getBestPuzzleTime()).toBe(2000);
+  });
   });
 });


### PR DESCRIPTION
## Summary
- track puzzle completion times in `progress` and expose helper APIs
- display best puzzle time and allow resetting times in the progress overlay
- start timing when the magic square puzzle begins
- respond to window resize by updating renderer and camera
- prefetch other levels and cache level modules offline
- test puzzle timing logic

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e589808b88328b95d3c72883b8630