### PR TITLE
Add gamepad, motion controls and sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Run the automated tests with Web Test Runner:
 npm test
 ```
 
+### Sharing Progress
+
+Use the **Share Progress** button in the progress overlay (press **P** to open) to
+share your best puzzle time and current level. The feature uses the Web Share API
+when available and falls back to copying text to the clipboard.
+
 ### Offline Play
 
 The game includes a service worker that caches key assets for offline use. After

--- a/app/gamepadControls.js
+++ b/app/gamepadControls.js
@@ -1,0 +1,41 @@
+const deadZone = 0.2;
+let move = {forward:0, backward:0, left:0, right:0};
+let look = {dx:0, dy:0};
+
+export function mapGamepad(gp){
+  const m = {forward:0, backward:0, left:0, right:0};
+  const l = {dx:0, dy:0};
+  if(!gp) return {move:m, look:l};
+  const lx = gp.axes[0] || 0;
+  const ly = gp.axes[1] || 0;
+  m.forward = ly < -deadZone ? 1 : 0;
+  m.backward = ly > deadZone ? 1 : 0;
+  m.left = lx < -deadZone ? 1 : 0;
+  m.right = lx > deadZone ? 1 : 0;
+  const rx = gp.axes[2] || 0;
+  const ry = gp.axes[3] || 0;
+  l.dx = Math.abs(rx) > deadZone ? rx : 0;
+  l.dy = Math.abs(ry) > deadZone ? ry : 0;
+  return {move:m, look:l};
+}
+
+export function initGamepadControls(){
+  function update(){
+    const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    const res = mapGamepad(pads[0]);
+    move = res.move;
+    look = res.look;
+    requestAnimationFrame(update);
+  }
+  requestAnimationFrame(update);
+}
+
+export function getGamepadMove(){
+  return move;
+}
+
+export function getGamepadLook(){
+  const l = {...look};
+  look.dx=0; look.dy=0;
+  return l;
+}

--- a/app/modules/controllers/controllers.first_person.js
+++ b/app/modules/controllers/controllers.first_person.js
@@ -10,6 +10,8 @@ import createMagicSquare from 'modules/puzzles/magic_square';
 import { markPuzzleSolved, markItemCollected, markLevelVisited, setCurrentLevel } from '../../progress';
 import { highlight, removeHighlight } from '../../highlightManager.js';
 import { initTouchControls, getMove, getLook } from '../../touchControls.js';
+import { initGamepadControls, getGamepadMove, getGamepadLook } from '../../gamepadControls.js';
+import { getMotionMove, getMotionLook } from '../../motionControls.js';
 
 const keyboard = new THREEx.KeyboardState();
 let controls;
@@ -223,16 +225,26 @@ keyboard.detectObjects = function(interact = false) {
         keyboard.update = function(_mesh, _camera) {
                 _mesh.add(_camera);
                 if (controls) {
-                        const move = getMove();
-                        if (keyboard.pressed("W") || move.forward) controls.moveForward(5);
-                        if (keyboard.pressed("S") || move.backward) controls.moveForward(-5);
-                        if (keyboard.pressed("A") || move.left) controls.moveRight(-5);
-                        if (keyboard.pressed("D") || move.right) controls.moveRight(5);
-                        const look = getLook();
-                        if (look.dx || look.dy) {
+                        const moveTouch = getMove();
+                        const movePad = getGamepadMove();
+                        const moveMotion = getMotionMove();
+                        const forward = moveTouch.forward || movePad.forward || moveMotion.forward;
+                        const backward = moveTouch.backward || movePad.backward || moveMotion.backward;
+                        const left = moveTouch.left || movePad.left || moveMotion.left;
+                        const right = moveTouch.right || movePad.right || moveMotion.right;
+                        if (keyboard.pressed("W") || forward) controls.moveForward(5);
+                        if (keyboard.pressed("S") || backward) controls.moveForward(-5);
+                        if (keyboard.pressed("A") || left) controls.moveRight(-5);
+                        if (keyboard.pressed("D") || right) controls.moveRight(5);
+                        const lookTouch = getLook();
+                        const lookPad = getGamepadLook();
+                        const lookMotion = getMotionLook();
+                        const dx = lookTouch.dx + lookPad.dx + lookMotion.dx;
+                        const dy = lookTouch.dy + lookPad.dy + lookMotion.dy;
+                        if (dx || dy) {
                                 const obj = controls.getObject();
-                                obj.rotation.y -= look.dx * 0.002;
-                                _camera.rotation.x -= look.dy * 0.002;
+                                obj.rotation.y -= dx * 0.002;
+                                _camera.rotation.x -= dy * 0.002;
                         }
                 }
                 this.collision(_mesh);

--- a/app/motionControls.js
+++ b/app/motionControls.js
@@ -1,0 +1,49 @@
+let enabled = false;
+let move = {forward:0, backward:0, left:0, right:0};
+let look = {dx:0, dy:0};
+let last = {beta:0, gamma:0};
+const thresh = 15;
+
+export function mapOrientation(beta, gamma){
+  const m = {forward:0, backward:0, left:0, right:0};
+  if(beta < -thresh) m.forward = 1;
+  if(beta > thresh) m.backward = 1;
+  if(gamma < -thresh) m.left = 1;
+  if(gamma > thresh) m.right = 1;
+  return m;
+}
+
+function handle(e){
+  move = mapOrientation(e.beta || 0, e.gamma || 0);
+  look.dx = (e.gamma - last.gamma) * 0.05;
+  look.dy = (e.beta - last.beta) * 0.05;
+  last.gamma = e.gamma; last.beta = e.beta;
+}
+
+export function enableMotionControls(){
+  if(enabled) return;
+  window.addEventListener('deviceorientation', handle);
+  enabled = true;
+}
+
+export function disableMotionControls(){
+  if(!enabled) return;
+  window.removeEventListener('deviceorientation', handle);
+  enabled = false;
+  move = {forward:0, backward:0, left:0, right:0};
+  look = {dx:0, dy:0};
+}
+
+export function getMotionMove(){
+  return move;
+}
+
+export function getMotionLook(){
+  const l = {...look};
+  look.dx=0; look.dy=0;
+  return l;
+}
+
+export function motionEnabled(){
+  return enabled;
+}

--- a/app/progressOverlay.js
+++ b/app/progressOverlay.js
@@ -1,5 +1,27 @@
 import { getProgress, resetProgress, getBestPuzzleTime, resetPuzzleTimes, getPuzzleTimesSorted } from './progress';
 import keyboard from 'modules/controllers/controllers.first_person';
+import { motionEnabled, enableMotionControls, disableMotionControls } from './motionControls.js';
+
+export function formatShareText() {
+  const best = getBestPuzzleTime();
+  const prog = getProgress();
+  const level = prog.currentLevel != null ? prog.currentLevel : 'unknown';
+  const bestText = best != null ? `${(best/1000).toFixed(1)}s` : 'N/A';
+  return `I'm on level ${level} with a best puzzle time of ${bestText} in The Dark Room!`;
+}
+
+export async function shareProgress() {
+  const text = formatShareText();
+  if (navigator.share) {
+    try { await navigator.share({ text }); return; } catch (e) { /* ignore */ }
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    alert('Progress copied to clipboard');
+  } catch (e) {
+    alert(text);
+  }
+}
 
 export function initProgressOverlay() {
   const overlay = document.createElement('div');
@@ -19,6 +41,8 @@ export function initProgressOverlay() {
     <button id="goLevel">Go</button>
     <button id="resetPuzzleTimes">Reset Puzzle Times</button>
     <button id="resetProgress">Reset Progress</button>
+    <button id="shareProgress">Share Progress</button>
+    <button id="toggleMotion">Enable Motion Controls</button>
   `;
   document.body.appendChild(overlay);
 
@@ -38,6 +62,7 @@ export function initProgressOverlay() {
     select.innerHTML = Object.keys(prog.levels).map(l => `<option value="${l}" ${prog.currentLevel==l?'selected':''}>${l}</option>`).join('');
   }
 
+
   overlay.querySelector('#resetProgress').addEventListener('click', () => {
     resetProgress();
     update();
@@ -52,6 +77,18 @@ export function initProgressOverlay() {
     const select = overlay.querySelector('#levelSelect');
     if (select && select.value) {
       keyboard.enterLevel(select.value);
+    }
+  });
+
+  overlay.querySelector('#shareProgress').addEventListener('click', shareProgress);
+
+  overlay.querySelector('#toggleMotion').addEventListener('click', () => {
+    if (motionEnabled()) {
+      disableMotionControls();
+      overlay.querySelector('#toggleMotion').textContent = 'Enable Motion Controls';
+    } else {
+      enableMotionControls();
+      overlay.querySelector('#toggleMotion').textContent = 'Disable Motion Controls';
     }
   });
 

--- a/app/router.js
+++ b/app/router.js
@@ -8,6 +8,7 @@ import keyboard from 'modules/controllers/controllers.first_person';
 import story from 'modules/story/story.main';
 import { getProgress } from './progress';
 import { initTouchControls } from './touchControls.js';
+import { initGamepadControls } from './gamepadControls.js';
 
 export default Backbone.Router.extend({
     routes: {
@@ -118,6 +119,7 @@ export default Backbone.Router.extend({
         currentScene.set('level', darkroom);
         keyboard.initPointerLock(cameraMain);
         initTouchControls();
+        initGamepadControls();
  
   
 

--- a/test/jasmine/specs/controllers/gamepadControls.spec.js
+++ b/test/jasmine/specs/controllers/gamepadControls.spec.js
@@ -1,0 +1,17 @@
+define(function(require) {
+  'use strict';
+  var gc = require('../../../../app/gamepadControls.js');
+
+  describe('gamepadControls mapGamepad', function() {
+    it('maps axes to movement and look', function() {
+      var gp = { axes: [1, -1, 0.5, -0.5] };
+      var res = gc.mapGamepad(gp);
+      expect(res.move.forward).toBe(1);
+      expect(res.move.backward).toBe(0);
+      expect(res.move.right).toBe(1);
+      expect(res.move.left).toBe(0);
+      expect(res.look.dx).toBe(0.5);
+      expect(res.look.dy).toBe(-0.5);
+    });
+  });
+});

--- a/test/jasmine/specs/controllers/motionControls.spec.js
+++ b/test/jasmine/specs/controllers/motionControls.spec.js
@@ -1,0 +1,14 @@
+define(function(require) {
+  'use strict';
+  var mc = require('../../../../app/motionControls.js');
+
+  describe('motionControls mapOrientation', function() {
+    it('converts beta and gamma to move flags', function() {
+      var m = mc.mapOrientation(-20, 20);
+      expect(m.forward).toBe(1);
+      expect(m.backward).toBe(0);
+      expect(m.right).toBe(1);
+      expect(m.left).toBe(0);
+    });
+  });
+});

--- a/test/jasmine/specs/progress/shareProgress.spec.js
+++ b/test/jasmine/specs/progress/shareProgress.spec.js
@@ -1,0 +1,22 @@
+define(function(require) {
+  'use strict';
+  var overlay = require('../../../../app/progressOverlay.js');
+  var progress = require('../../../../app/progress.js');
+
+  describe('share text formatting', function() {
+    afterEach(function() { progress.resetProgress(); });
+
+    it('builds summary string', function() {
+      progress.resetProgress();
+      progress.setCurrentLevel('test');
+      progress.startPuzzle();
+      jasmine.clock().install();
+      jasmine.clock().tick(1000);
+      progress.markPuzzleSolved();
+      jasmine.clock().uninstall();
+      var text = overlay.formatShareText();
+      expect(text).toContain('level test');
+      expect(text).toContain('1.0s');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- support Gamepad API polling
- add device orientation controls
- allow sharing progress via Web Share API
- wire new input sources into the first person controller
- document how to share progress
- test gamepad and motion controls mapping and share text formatting

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ede7f76e483288f06bd39beb3b492