### PR TITLE
Add interactive puzzle UI and control help overlay

### DIFF
--- a/app/helpOverlay.js
+++ b/app/helpOverlay.js
@@ -1,0 +1,69 @@
+export function initHelpOverlay() {
+  const overlay = document.createElement('div');
+  overlay.id = 'helpOverlay';
+  overlay.innerHTML = `
+    <h2>Controls</h2>
+    <div id="keyboardHelp">
+      <h3>Keyboard</h3>
+      <p>WASD to move, Space to interact, M to mute, P for progress</p>
+    </div>
+    <div id="gamepadHelp" style="display:none;">
+      <h3>Gamepad</h3>
+      <p>Left stick to move, Right stick to look, Button South to interact</p>
+    </div>
+    <div id="touchHelp" style="display:none;">
+      <h3>Touch</h3>
+      <p>Use on-screen joysticks to move and look</p>
+    </div>
+    <div id="motionHelp" style="display:none;">
+      <h3>Motion</h3>
+      <p>Tilt device to move and look</p>
+    </div>
+    <button id="closeHelp">Close</button>
+  `;
+  overlay.style.display = 'none';
+  document.body.appendChild(overlay);
+
+  const closeBtn = overlay.querySelector('#closeHelp');
+  closeBtn.addEventListener('click', () => {
+    overlay.style.display = 'none';
+    localStorage.setItem('helpHidden', 'true');
+  });
+
+  function showHelp() {
+    overlay.style.display = 'block';
+    localStorage.setItem('helpHidden', 'false');
+  }
+
+  function detectControl(e) {
+    if (e.type === 'gamepadconnected') {
+      overlay.querySelector('#gamepadHelp').style.display = 'block';
+    } else if (e.type === 'touchstart') {
+      overlay.querySelector('#touchHelp').style.display = 'block';
+      window.removeEventListener('touchstart', detectControl);
+    } else if (e.type === 'deviceorientation') {
+      overlay.querySelector('#motionHelp').style.display = 'block';
+      window.removeEventListener('deviceorientation', detectControl);
+    } else if (e.type === 'keydown') {
+      overlay.querySelector('#keyboardHelp').style.display = 'block';
+    }
+  }
+
+  window.addEventListener('gamepadconnected', detectControl, { once: true });
+  window.addEventListener('touchstart', detectControl, { once: true });
+  window.addEventListener('deviceorientation', detectControl, { once: true });
+  window.addEventListener('keydown', detectControl, { once: true });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.code === 'KeyH') {
+      overlay.style.display = overlay.style.display === 'block' ? 'none' : 'block';
+      localStorage.setItem('helpHidden', overlay.style.display === 'none' ? 'true' : 'false');
+    }
+  });
+
+  if (localStorage.getItem('helpHidden') !== 'true') {
+    showHelp();
+  }
+}
+
+export default { initHelpOverlay };

--- a/app/main.ts
+++ b/app/main.ts
@@ -3,6 +3,7 @@ import app from './app.js';
 import Router from './router.js';
 import { initAudioToggle } from './audioToggle.js';
 import { initProgressOverlay } from './progressOverlay.js';
+import { initHelpOverlay } from './helpOverlay.js';
 
 app.router = new Router();
 
@@ -13,5 +14,6 @@ Backbone.history.start({
 
 initAudioToggle();
 initProgressOverlay();
+initHelpOverlay();
 
 export default app;

--- a/app/modules/levels/levels.dinner_party.js
+++ b/app/modules/levels/levels.dinner_party.js
@@ -1,61 +1,33 @@
-define(function(require, exports, module) {
-	"use strict";
+import * as THREE from 'three';
 
-	var $ = require("jquery");
-	var _ = require("underscore");
-	var Backbone = require("backbone");
-	var THREE = require('three');
-	var app = require("app");
+const ScreenScene = {
+  initialize() {
+    this.screenScene = new THREE.Scene();
+    this.screenCamera = new THREE.OrthographicCamera(
+      window.innerWidth / -2,
+      window.innerWidth / 2,
+      window.innerHeight / 2,
+      window.innerHeight / -2,
+      -10000,
+      10000
+    );
+    this.screenCamera.position.z = 1000;
+    this.screenScene.add(this.screenCamera);
 
+    this.screenGeometry = new THREE.PlaneGeometry(window.innerWidth, window.innerHeight);
+    this.firstRenderTarget = new THREE.WebGLRenderTarget(512, 512, { format: THREE.RGBFormat });
+    this.screenMaterial = new THREE.MeshBasicMaterial({ map: this.firstRenderTarget });
+    this.quad = new THREE.Mesh(this.screenGeometry, this.screenMaterial);
+    this.screenScene.add(this.quad);
 
-	// intermediate scene.
-	//   this solves the problem of the mirrored texture by mirroring it again.
-	//   consists of a camera looking at a plane with the mirrored texture on it. 
+    this.planeGeometry = new THREE.CubeGeometry(200, 100, 1, 1);
+    this.finalRenderTarget = new THREE.WebGLRenderTarget(512, 512, { format: THREE.RGBFormat });
+    this.planeMaterial = new THREE.MeshBasicMaterial({ map: this.finalRenderTarget });
+    this.plane1 = new THREE.Mesh(this.planeGeometry, this.planeMaterial);
+    this.plane1.position.set(0, 100, 500);
+  }
+};
 
-	var ScreenScene = {
-		initialize: function() {
+ScreenScene.initialize();
 
-			this.screenScene = new THREE.Scene();
-
-			this.screenCamera = new THREE.OrthographicCamera(
-				window.innerWidth / -2, window.innerWidth / 2,
-				window.innerHeight / 2, window.innerHeight / -2, -10000, 10000);
-			this.screenCamera.position.z = 1000;
-			this.screenScene.add(this.screenCamera);
-
-			this.screenGeometry = new THREE.PlaneGeometry(window.innerWidth, window.innerHeight);
-
-			this.firstRenderTarget = new THREE.WebGLRenderTarget(512, 512, {
-				format: THREE.RGBFormat
-			});
-			this.screenMaterial = new THREE.MeshBasicMaterial({
-				map: this.firstRenderTarget
-			});
-
-			this.quad = new THREE.Mesh(this.screenGeometry, this.screenMaterial);
-			// quad.rotation.x = Math.PI / 2;
-			this.screenScene.add(this.quad);
-
-			// final version of camera texture, used in scene. 
-			this.planeGeometry = new THREE.CubeGeometry(200, 100, 1, 1);
-			this.finalRenderTarget = new THREE.WebGLRenderTarget(512, 512, {
-				format: THREE.RGBFormat
-			});
-			this.planeMaterial = new THREE.MeshBasicMaterial({
-				map: this.finalRenderTarget
-			});
-			this.plane1 = new THREE.Mesh(this.planeGeometry, this.planeMaterial);
-			this.plane1.position.set(0, 100, 500);
-		},
-
-
-	}
-
-
-	ScreenScene.initialize();
-
-
-
-
-	module.exports = ScreenScene;
-});
+export default ScreenScene;

--- a/app/modules/puzzles/magic_square.js
+++ b/app/modules/puzzles/magic_square.js
@@ -15,6 +15,34 @@ export default function createMagicSquare(onSolved) {
 
   const container = document.createElement('div');
   container.id = 'magicSquare';
+  const timerEl = document.createElement('div');
+  timerEl.id = 'puzzleTimer';
+  container.appendChild(timerEl);
+  const grid = document.createElement('div');
+  grid.id = 'magicGrid';
+  grid.style.display = 'grid';
+  grid.style.gridTemplateColumns = 'repeat(3, 50px)';
+  grid.style.gridGap = '5px';
+  container.appendChild(grid);
+
+  const keypad = document.createElement('div');
+  keypad.id = 'magicKeypad';
+  keypad.style.marginTop = '10px';
+  keypad.style.display = 'grid';
+  keypad.style.gridTemplateColumns = 'repeat(3, 40px)';
+  keypad.style.gridGap = '5px';
+  container.appendChild(keypad);
+
+  let selected = null;
+
+  function updateTimer(start) {
+    const now = Date.now();
+    timerEl.textContent = ((now - start) / 1000).toFixed(1) + 's';
+    if (!container.classList.contains('solved')) {
+      requestAnimationFrame(() => updateTimer(start));
+    }
+  }
+  updateTimer(Date.now());
 
   function check() {
     for (let i = 0; i < 3; i++) {
@@ -37,17 +65,26 @@ export default function createMagicSquare(onSolved) {
       cell.dataset.col = j;
       cell.textContent = '';
       cell.addEventListener('click', () => {
-        const val = prompt('Enter number 1-9');
-        if (!val) return;
-        const n = parseInt(val, 10);
-        cell.textContent = n;
-        state[i][j] = n;
-        check();
+        selected = cell;
       });
-      container.appendChild(cell);
+      grid.appendChild(cell);
     }
+  }
+
+  for (let n = 1; n <= 9; n++) {
+    const btn = document.createElement('div');
+    btn.className = 'magic-key';
+    btn.textContent = String(n);
+    btn.addEventListener('click', () => {
+      if (!selected) return;
+      selected.textContent = String(n);
+      const r = parseInt(selected.dataset.row, 10);
+      const c = parseInt(selected.dataset.col, 10);
+      state[r][c] = n;
+      check();
+    });
+    keypad.appendChild(btn);
   }
 
   document.body.appendChild(container);
 }
-

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -82,10 +82,35 @@ margin-top:200px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.8);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#magicGrid {
   display: grid;
   grid-template-columns: repeat(3, 50px);
-  grid-template-rows: repeat(3, 50px);
   gap: 5px;
+}
+
+#magicKeypad {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(3, 40px);
+  gap: 5px;
+}
+
+.magic-key {
+  width: 40px;
+  height: 40px;
+  background: #333;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
 }
 
 .magic-cell {
@@ -140,4 +165,26 @@ margin-top:200px;
 #joystickRight { right: 20px; }
 @media (min-width: 800px) {
   #joystickLeft, #joystickRight { display: none; }
+}
+
+#helpOverlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.9);
+  color: white;
+  padding: 20px;
+  z-index: 1000;
+}
+#helpOverlay h2, #helpOverlay h3 {
+  margin: 0 0 5px;
+}
+#helpOverlay button {
+  margin-top: 10px;
+}
+
+#puzzleTimer {
+  margin-bottom: 5px;
+  color: #fff;
 }

--- a/test/jasmine/specs/progress/progress.spec.js
+++ b/test/jasmine/specs/progress/progress.spec.js
@@ -30,5 +30,19 @@ define(function(require) {
     expect(progress.getProgress().puzzleTimes[0]).toBe(2000);
     expect(progress.getBestPuzzleTime()).toBe(2000);
   });
+
+  it('tracks multiple puzzle attempts', function() {
+    progress.resetProgress();
+    progress.startPuzzle();
+    jasmine.clock().install();
+    jasmine.clock().tick(1500);
+    progress.markPuzzleSolved();
+    progress.startPuzzle();
+    jasmine.clock().tick(1000);
+    progress.markPuzzleSolved();
+    jasmine.clock().uninstall();
+    expect(progress.getProgress().puzzleTimes.length).toBe(2);
+    expect(progress.getBestPuzzleTime()).toBe(1000);
+  });
   });
 });


### PR DESCRIPTION
## Summary
- add in-game help overlay with context-aware control hints
- create keypad UI and timer for magic square puzzle
- convert dinner party level to ES module
- track multiple puzzle attempts in progress tests

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402248e7f4832899acd7f2849a0a27