### PR TITLE
Add admin overlay

### DIFF
--- a/app/adminOverlay.ts
+++ b/app/adminOverlay.ts
@@ -1,0 +1,52 @@
+import { getProgress, resetProgress } from './progress';
+import keyboard from 'modules/controllers/controllers.first_person';
+
+export function initAdminOverlay(): void {
+  const overlay = document.createElement('div');
+  overlay.id = 'adminOverlay';
+  overlay.style.display = 'none';
+  overlay.innerHTML = `
+    <h2>Admin Panel</h2>
+    <pre id="adminProgress"></pre>
+    <div>
+      <input id="adminLevel" placeholder="Level id" />
+      <button id="adminGoLevel">Go</button>
+    </div>
+    <button id="adminReset">Reset Progress</button>
+    <button id="adminClose">Close</button>
+  `;
+  document.body.appendChild(overlay);
+
+  const progressPre = overlay.querySelector<HTMLPreElement>('#adminProgress')!;
+  const levelInput = overlay.querySelector<HTMLInputElement>('#adminLevel')!;
+  const goBtn = overlay.querySelector<HTMLButtonElement>('#adminGoLevel')!;
+  const resetBtn = overlay.querySelector<HTMLButtonElement>('#adminReset')!;
+  const closeBtn = overlay.querySelector<HTMLButtonElement>('#adminClose')!;
+
+  function update() {
+    progressPre.textContent = JSON.stringify(getProgress(), null, 2);
+  }
+
+  goBtn.addEventListener('click', () => {
+    const val = levelInput.value.trim();
+    if (val) keyboard.enterLevel(val);
+  });
+
+  resetBtn.addEventListener('click', () => {
+    resetProgress();
+    update();
+  });
+
+  closeBtn.addEventListener('click', () => {
+    overlay.style.display = 'none';
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.code === 'KeyO') {
+      overlay.style.display = overlay.style.display === 'block' ? 'none' : 'block';
+      if (overlay.style.display === 'block') update();
+    }
+  });
+}
+
+export default { initAdminOverlay };

--- a/app/main.ts
+++ b/app/main.ts
@@ -4,6 +4,7 @@ import Router from './router.js';
 import { initAudioToggle } from './audioToggle.js';
 import { initProgressOverlay } from './progressOverlay.js';
 import { initHelpOverlay } from './helpOverlay.js';
+import { initAdminOverlay } from './adminOverlay';
 
 app.router = new Router();
 
@@ -15,5 +16,6 @@ Backbone.history.start({
 initAudioToggle();
 initProgressOverlay();
 initHelpOverlay();
+initAdminOverlay();
 
 export default app;

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Then visit [http://localhost:3333](http://localhost:3333).
 - **Space** – Perform the action specified in the level.
 - **M** – Toggle audio (also available via on-screen button).
 - **P** – Open the progress overlay and share your progress.
+- **O** – Toggle the admin panel to view and edit saved progress.
 
 ### Running Tests
 


### PR DESCRIPTION
## Summary
- create an admin overlay for viewing and editing progress
- wire the overlay into the main bootstrap
- document the new `O` keyboard shortcut

## Testing
- `npm run build` *(fails: webpack not found)*
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840deac8dc483289e42399e48d8517f