### PR TITLE
Add fullscreen toggle feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For an in-depth guide covering installation, controls, and offline support, see
 - **Multiple Control Schemes** – Play with keyboard, gamepad, or touch.
 - **Puzzle Progression** – Navigate rooms and solve challenges.
 - **Audio Toggle** – Mute or unmute with the on-screen button or `M`.
+- **Fullscreen Mode** – Press `F` or use the on-screen button for fullscreen.
 - **Share Progress** – Share your best times via the Web Share API.
 - **Offline Support** – Works without a network connection after first load.
 
@@ -56,6 +57,7 @@ Then open [http://localhost:3333](http://localhost:3333) in your browser.
 
 Use the **Mute** button (or press **M**) to toggle audio. The preference
 persists across sessions.
+Use the **Fullscreen** button (or press **F**) for an immersive experience.
 
 ### Running Tests
 

--- a/app/fullscreenToggle.js
+++ b/app/fullscreenToggle.js
@@ -1,0 +1,19 @@
+export function initFullscreenToggle() {
+  const btn = document.getElementById('fullscreenToggle');
+  if (!btn) return;
+  function toggle() {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen().catch(() => {});
+      btn.textContent = 'Exit Fullscreen';
+    } else {
+      document.exitFullscreen();
+      btn.textContent = 'Fullscreen';
+    }
+  }
+  btn.addEventListener('click', toggle);
+  document.addEventListener('keydown', (e) => {
+    if (e.code === 'KeyF') toggle();
+  });
+}
+
+export default { initFullscreenToggle };

--- a/app/helpOverlay.js
+++ b/app/helpOverlay.js
@@ -5,7 +5,7 @@ export function initHelpOverlay() {
     <h2>Controls</h2>
     <div id="keyboardHelp">
       <h3>Keyboard</h3>
-      <p>WASD to move, Space to interact, M to mute, P for progress</p>
+      <p>WASD to move, Space to interact, M to mute, P for progress, F for fullscreen</p>
     </div>
     <div id="gamepadHelp" style="display:none;">
       <h3>Gamepad</h3>

--- a/app/main.ts
+++ b/app/main.ts
@@ -2,6 +2,7 @@ import Backbone from 'backbone';
 import app from './app.js';
 import Router from './router.js';
 import { initAudioToggle } from './audioToggle.js';
+import { initFullscreenToggle } from './fullscreenToggle.js';
 import { initProgressOverlay } from './progressOverlay.js';
 import { initHelpOverlay } from './helpOverlay.js';
 import { initAdminOverlay } from './adminOverlay';
@@ -14,6 +15,7 @@ Backbone.history.start({
 });
 
 initAudioToggle();
+initFullscreenToggle();
 initProgressOverlay();
 initHelpOverlay();
 initAdminOverlay();

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ The Dark Room is a browser-based game built with WebGL and Three.js. It creates 
 - **Multiple Control Schemes** – Play with keyboard, gamepad, or touch controls.
 - **Puzzle Progression** – Navigate rooms, interact with objects, and complete challenges to advance.
 - **Audio Toggle** – Mute or unmute background audio with the on-screen button or the `M` key.
+- **Fullscreen Mode** – Press `F` or use the on-screen button to enter or exit fullscreen.
 - **Share Progress** – Quickly share your best puzzle times using the Web Share API or clipboard.
 - **Offline Support** – After an initial visit, the game works without a network connection thanks to a service worker.
 
@@ -38,6 +39,7 @@ Then visit [http://localhost:3333](http://localhost:3333).
 - **Space** – Perform the action specified in the level.
 - **M** – Toggle audio (also available via on-screen button).
 - **P** – Open the progress overlay and share your progress.
+- **F** – Toggle fullscreen mode.
 - **O** – Toggle the admin panel to view and edit saved progress.
 
 ### Running Tests

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
   <audio id="bgMusic" src="/app/sound/darkRoomSONG.mp3" autoplay loop></audio>
   <audio id="vocals" src="/app/sound/vocal0.mp3" autoplay loop></audio>
   <button id="audioToggle">Mute</button>
+  <button id="fullscreenToggle">Fullscreen</button>
   <div id="pointerHint">Click to lock pointer, press P to view progress</div>
   <div id="crosshair">+</div>
   <div id="joystickLeft"></div>


### PR DESCRIPTION
## Summary
- allow entering fullscreen with a new button and `F` key
- list fullscreen support in the documentation and help overlay
- document fullscreen usage in README files

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413658957c83288e841ced4ca09f77