### PR TITLE
Add puzzle restart key

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ dan dugan
 
 
 Use **WASD** or the **arrow keys** to move around. Press the space bar to perform the action the level requires... definitely a work in progress!
+Press **R** during a puzzle to quickly restart your attempt.
 
 ## Local Development
 

--- a/app/modules/puzzles/magic_square.js
+++ b/app/modules/puzzles/magic_square.js
@@ -2,6 +2,7 @@ import { startPuzzle } from '../../progress';
 
 export default function createMagicSquare(onSolved) {
   startPuzzle();
+  let startTime = Date.now();
   const target = [
     [8, 1, 6],
     [3, 5, 7],
@@ -33,6 +34,12 @@ export default function createMagicSquare(onSolved) {
   keypad.style.gridGap = '5px';
   container.appendChild(keypad);
 
+  const restartBtn = document.createElement('button');
+  restartBtn.id = 'restartPuzzle';
+  restartBtn.textContent = 'Restart';
+  restartBtn.addEventListener('click', restart);
+  container.appendChild(restartBtn);
+
   let selected = null;
 
   function updateTimer(start) {
@@ -42,7 +49,7 @@ export default function createMagicSquare(onSolved) {
       requestAnimationFrame(() => updateTimer(start));
     }
   }
-  updateTimer(Date.now());
+  updateTimer(startTime);
 
   function check() {
     for (let i = 0; i < 3; i++) {
@@ -54,7 +61,22 @@ export default function createMagicSquare(onSolved) {
     }
     container.classList.add('solved');
     if (typeof onSolved === 'function') onSolved();
-    setTimeout(() => container.remove(), 1000);
+    setTimeout(() => {
+      container.remove();
+      document.removeEventListener('keydown', onKeyDown);
+    }, 1000);
+  }
+
+  function restart() {
+    container.classList.remove('solved');
+    startPuzzle();
+    startTime = Date.now();
+    state.forEach(row => row.fill(''));
+    grid.querySelectorAll('.magic-cell').forEach(cell => {
+      cell.textContent = '';
+    });
+    selected = null;
+    updateTimer(startTime);
   }
 
   for (let i = 0; i < 3; i++) {
@@ -87,4 +109,11 @@ export default function createMagicSquare(onSolved) {
   }
 
   document.body.appendChild(container);
+
+  function onKeyDown(e) {
+    if (e.code === 'KeyR') {
+      restart();
+    }
+  }
+  document.addEventListener('keydown', onKeyDown);
 }

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -102,6 +102,10 @@ margin-top:200px;
   gap: 5px;
 }
 
+#restartPuzzle {
+  margin-top: 10px;
+}
+
 .magic-key {
   width: 40px;
   height: 40px;

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Then visit [http://localhost:3333](http://localhost:3333).
 - **P** – Open the progress overlay and share your progress.
 - **F** – Toggle fullscreen mode.
 - **O** – Toggle the admin panel to view and edit saved progress.
+- **R** – Restart the current puzzle when one is active.
 
 ### Running Tests
 


### PR DESCRIPTION
## Summary
- add ability to restart the magic square puzzle
- style restart button
- document the `R` key for restarting puzzles

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841593af8c08328a439956ce9e4cf45