### PR TITLE
Add settings overlay for remappable controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For an in-depth guide covering installation, controls, and offline support, see
 - **Fullscreen Mode** – Press `F` or use the on-screen button for fullscreen.
 - **Share Progress** – Share your best times via the Web Share API.
 - **Offline Support** – Works without a network connection after first load.
+- **Customizable Controls** – Press `Escape` to remap movement and interaction keys.
 
 with:
 
@@ -30,6 +31,7 @@ dan dugan
 
 
 Use **WASD** or the **arrow keys** to move around. Press the space bar to perform the action the level requires... definitely a work in progress!
+Press **Escape** at any time to open the settings overlay and remap the movement or interaction keys. Your choices persist locally.
 Press **R** during a puzzle to quickly restart your attempt.
 
 ## Local Development

--- a/app/main.ts
+++ b/app/main.ts
@@ -6,6 +6,7 @@ import { initFullscreenToggle } from './fullscreenToggle.js';
 import { initProgressOverlay } from './progressOverlay.js';
 import { initHelpOverlay } from './helpOverlay.js';
 import { initAdminOverlay } from './adminOverlay';
+import { initSettingsOverlay } from './settingsOverlay.js';
 
 app.router = new Router();
 
@@ -19,5 +20,6 @@ initFullscreenToggle();
 initProgressOverlay();
 initHelpOverlay();
 initAdminOverlay();
+initSettingsOverlay();
 
 export default app;

--- a/app/modules/controllers/controllers.first_person.js
+++ b/app/modules/controllers/controllers.first_person.js
@@ -12,9 +12,21 @@ import { highlight, removeHighlight } from '../../highlightManager.js';
 import { initTouchControls, getMove, getLook } from '../../touchControls.js';
 import { initGamepadControls, getGamepadMove, getGamepadLook } from '../../gamepadControls.js';
 import { getMotionMove, getMotionLook } from '../../motionControls.js';
+import { loadKeyBindings } from '../../settingsOverlay.js';
 
 const keyboard = new THREEx.KeyboardState();
 let controls;
+let keyBindings = loadKeyBindings();
+
+function eventMatches(e, alias) {
+  const name = alias.toLowerCase();
+  if (name === 'space') return e.code === 'Space';
+  if (name === 'up') return e.code === 'ArrowUp';
+  if (name === 'down') return e.code === 'ArrowDown';
+  if (name === 'left') return e.code === 'ArrowLeft';
+  if (name === 'right') return e.code === 'ArrowRight';
+  return e.key && e.key.toUpperCase() === alias.toUpperCase();
+}
 
 keyboard.initPointerLock = function(camera) {
   controls = new PointerLockControls(camera, document.body);
@@ -27,7 +39,7 @@ keyboard.initPointerLock = function(camera) {
     const hint = document.getElementById('pointerHint');
     if (hint) hint.style.display = 'block';
   });
-};
+}; 
 
 document.addEventListener('keydown', (e) => {
   if (e.code === 'KeyO') {
@@ -37,12 +49,15 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
+document.addEventListener('keyBindingsSaved', (e) => {
+  keyBindings = e.detail;
+});
+
  
 
 
- $('body').keyup(function(e) {
-
- if(e.which===32){
+$('body').keyup(function(e) {
+ if(eventMatches(e, keyBindings.interact)){
         var canInteract=keyboard.detectObjects(true)
  }
  else if(e.which===77){
@@ -232,10 +247,10 @@ keyboard.detectObjects = function(interact = false) {
                         const backward = moveTouch.backward || movePad.backward || moveMotion.backward;
                         const left = moveTouch.left || movePad.left || moveMotion.left;
                         const right = moveTouch.right || movePad.right || moveMotion.right;
-                        if (keyboard.pressed("W") || keyboard.pressed("up") || forward) controls.moveForward(5);
-                        if (keyboard.pressed("S") || keyboard.pressed("down") || backward) controls.moveForward(-5);
-                        if (keyboard.pressed("A") || keyboard.pressed("left") || left) controls.moveRight(-5);
-                        if (keyboard.pressed("D") || keyboard.pressed("right") || right) controls.moveRight(5);
+                        if (keyboard.pressed(keyBindings.forward) || keyboard.pressed("up") || forward) controls.moveForward(5);
+                        if (keyboard.pressed(keyBindings.backward) || keyboard.pressed("down") || backward) controls.moveForward(-5);
+                        if (keyboard.pressed(keyBindings.left) || keyboard.pressed("left") || left) controls.moveRight(-5);
+                        if (keyboard.pressed(keyBindings.right) || keyboard.pressed("right") || right) controls.moveRight(5);
                         const lookTouch = getLook();
                         const lookPad = getGamepadLook();
                         const lookMotion = getMotionLook();

--- a/app/settingsOverlay.js
+++ b/app/settingsOverlay.js
@@ -1,0 +1,96 @@
+export const DEFAULT_BINDINGS = {
+  forward: 'W',
+  backward: 'S',
+  left: 'A',
+  right: 'D',
+  interact: 'space'
+};
+
+export function loadKeyBindings() {
+  try {
+    const stored = JSON.parse(localStorage.getItem('keyBindings') || 'null');
+    return { ...DEFAULT_BINDINGS, ...stored };
+  } catch (e) {
+    return { ...DEFAULT_BINDINGS };
+  }
+}
+
+export function saveKeyBindings(bindings) {
+  localStorage.setItem('keyBindings', JSON.stringify(bindings));
+}
+
+function createInput(id, label, value) {
+  const wrap = document.createElement('div');
+  const lbl = document.createElement('label');
+  lbl.textContent = label + ': ';
+  const input = document.createElement('input');
+  input.id = id;
+  input.value = value;
+  lbl.appendChild(input);
+  wrap.appendChild(lbl);
+  return { wrap, input };
+}
+
+export function initSettingsOverlay() {
+  const overlay = document.createElement('div');
+  overlay.id = 'settingsOverlay';
+  overlay.style.display = 'none';
+
+  const bindings = loadKeyBindings();
+
+  const elements = {
+    forward: createInput('bindForward', 'Forward', bindings.forward),
+    backward: createInput('bindBackward', 'Backward', bindings.backward),
+    left: createInput('bindLeft', 'Left', bindings.left),
+    right: createInput('bindRight', 'Right', bindings.right),
+    interact: createInput('bindInteract', 'Interact', bindings.interact)
+  };
+
+  overlay.appendChild(document.createElement('h2')).textContent = 'Key Bindings';
+  Object.values(elements).forEach(obj => overlay.appendChild(obj.wrap));
+
+  const saveBtn = document.createElement('button');
+  saveBtn.id = 'saveBindings';
+  saveBtn.textContent = 'Save';
+  overlay.appendChild(saveBtn);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.id = 'closeSettings';
+  closeBtn.textContent = 'Close';
+  overlay.appendChild(closeBtn);
+
+  document.body.appendChild(overlay);
+
+  function populate() {
+    const map = loadKeyBindings();
+    Object.keys(elements).forEach(k => {
+      elements[k].input.value = map[k];
+    });
+  }
+
+  saveBtn.addEventListener('click', () => {
+    const newMap = {
+      forward: elements.forward.input.value || DEFAULT_BINDINGS.forward,
+      backward: elements.backward.input.value || DEFAULT_BINDINGS.backward,
+      left: elements.left.input.value || DEFAULT_BINDINGS.left,
+      right: elements.right.input.value || DEFAULT_BINDINGS.right,
+      interact: elements.interact.input.value || DEFAULT_BINDINGS.interact
+    };
+    saveKeyBindings(newMap);
+    document.dispatchEvent(new CustomEvent('keyBindingsSaved', { detail: newMap }));
+    overlay.style.display = 'none';
+  });
+
+  closeBtn.addEventListener('click', () => {
+    overlay.style.display = 'none';
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.code === 'Escape') {
+      overlay.style.display = overlay.style.display === 'block' ? 'none' : 'block';
+      if (overlay.style.display === 'block') populate();
+    }
+  });
+}
+
+export default { initSettingsOverlay, loadKeyBindings, saveKeyBindings };

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -192,3 +192,22 @@ margin-top:200px;
   margin-bottom: 5px;
   color: #fff;
 }
+
+#settingsOverlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.9);
+  color: white;
+  padding: 20px;
+  z-index: 1000;
+  display: none;
+}
+#settingsOverlay label {
+  display: block;
+  margin-bottom: 5px;
+}
+#settingsOverlay button {
+  margin-top: 10px;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ The Dark Room is a browser-based game built with WebGL and Three.js. It creates 
 - **Fullscreen Mode** – Press `F` or use the on-screen button to enter or exit fullscreen.
 - **Share Progress** – Quickly share your best puzzle times using the Web Share API or clipboard.
 - **Offline Support** – After an initial visit, the game works without a network connection thanks to a service worker.
+- **Customizable Controls** – Press `Escape` to open the settings overlay and remap keys.
 
 ## Installation
 
@@ -41,7 +42,10 @@ Then visit [http://localhost:3333](http://localhost:3333).
 - **P** – Open the progress overlay and share your progress.
 - **F** – Toggle fullscreen mode.
 - **O** – Toggle the admin panel to view and edit saved progress.
+- **Escape** – Open the settings overlay to customize controls.
 - **R** – Restart the current puzzle when one is active.
+
+Your key selections are saved in the browser so they'll be restored on the next visit.
 
 ### Running Tests
 


### PR DESCRIPTION
## Summary
- allow customizing movement/interact keys with new settings overlay
- persist key bindings in localStorage
- read key map in first-person controller instead of hard coding WASD
- toggle the settings overlay with the Escape key
- document customizable controls

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415cea9d6483289eb0b04de8633d6c