### PR TITLE
Fix progress overlay toggle text

### DIFF
--- a/app/progressOverlay.js
+++ b/app/progressOverlay.js
@@ -49,6 +49,12 @@ export function initProgressOverlay() {
 
   function update() {
     const prog = getProgress();
+    const motionBtn = overlay.querySelector('#toggleMotion');
+    if (motionBtn) {
+      motionBtn.textContent = motionEnabled()
+        ? 'Disable Motion Controls'
+        : 'Enable Motion Controls';
+    }
     const visited = overlay.querySelector('#visitedList');
     visited.innerHTML = Object.keys(prog.levels).map(l => `<li>${l}</li>`).join('') || '<li>None</li>';
     const items = overlay.querySelector('#itemsList');


### PR DESCRIPTION
## Summary
- ensure progress overlay's motion toggle displays correct state

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_684166bb52a88328b8edbea930772693