### PR TITLE
Bump Express

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "name": "dark-room",
   "version": "0.1.0",
   "dependencies": {
-    "express": "^4.13.1",
+    "express": "^4.18.2",
     "jquery": "^3.7.1",
     "underscore": "^1.13.6",
     "backbone": "^1.5.0",


### PR DESCRIPTION
## Summary
- bump Express to 4.18.2

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_684241be55c48328bb2a25374cace36c