### PR TITLE
Handle clipboard API fallback

### DIFF
--- a/app/progressOverlay.js
+++ b/app/progressOverlay.js
@@ -16,8 +16,12 @@ export async function shareProgress() {
     try { await navigator.share({ text }); return; } catch (e) { /* ignore */ }
   }
   try {
-    await navigator.clipboard.writeText(text);
-    alert('Progress copied to clipboard');
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      alert('Progress copied to clipboard');
+    } else {
+      throw new Error('Clipboard API unavailable');
+    }
   } catch (e) {
     alert(text);
   }


### PR DESCRIPTION
## Summary
- detect if `navigator.clipboard` exists before calling `writeText`
- fall back to alerting the share text if the Clipboard API is unavailable

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842440f41bc8328b6fa5bb5d4f7cfa7