### PR TITLE
Update Express server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ npm run dev
 
 Then open [http://localhost:3333](http://localhost:3333) in your browser.
 
+You can also hit [http://localhost:3333/health](http://localhost:3333/health)
+to confirm the Express server is responding.
+
 Use the **Mute** button (or press **M**) to toggle audio. The preference
 persists across sessions.
 Use the **Fullscreen** button (or press **F**) for an immersive experience.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,9 @@ npm start
 
 Then visit [http://localhost:3333](http://localhost:3333).
 
+To verify the server is running, open [http://localhost:3333/health](http://localhost:3333/health)
+to see a simple JSON status response.
+
 ### Keyboard Shortcuts
 
 - **WASD** or **Arrow Keys** – Move around the level.

--- a/server.js
+++ b/server.js
@@ -1,4 +1,26 @@
-var express = require('express');
-var app = express();
-app.use(express.static(__dirname + '/'));
-app.listen(process.env.PORT || 3333);
+const express = require('express');
+const path = require('path');
+
+const app = express();
+
+// Disable the X-Powered-By header for security
+app.disable('x-powered-by');
+
+// Serve static files from the project root
+app.use(express.static(path.join(__dirname)));
+
+// Example async route using Express 5's promise support
+app.get('/health', async (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+// Basic error handler
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: err.message });
+});
+
+const port = process.env.PORT || 3333;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- upgrade server to Express 5 syntax
- add `/health` endpoint
- document new endpoint in both READMEs

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: Did not find any tests to run)*
- `PORT=3333 npm start --silent &` then `curl -s http://localhost:3333/health`

------
https://chatgpt.com/codex/tasks/task_e_68424c25d2c08328b744be66d3362025