### PR TITLE
Add QA documentation and automation

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,22 @@
+name: QA
+
+on:
+  pull_request:
+  push:
+    branches: ['*']
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run qa
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 dist/bundle.js
+coverage/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The Dark Room is a WebGL world rendered entirely with text. It places players in
 
 For an in-depth guide covering installation, controls, and offline support, see
 [the documentation](docs/README.md).
+For QA setup instructions, see [the QA guide](docs/QA_GUIDE.md).
+
 
 ![alt tag](http://i.imgur.com/BTIl5zC.png)
 ![alt tag](http://i.imgur.com/7emZTB1.png)

--- a/docs/QA_GUIDE.md
+++ b/docs/QA_GUIDE.md
@@ -1,0 +1,51 @@
+# QA Guide
+
+This guide outlines how to set up and test **The Dark Room** locally.
+
+## Prerequisites
+
+- **Node.js v18 or later**
+- A modern web browser (Chrome, Firefox, or Edge)
+
+## Getting Started
+
+1. Install project dependencies and build the bundle:
+   ```bash
+   npm install
+   npm run build
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+3. Open [http://localhost:3333](http://localhost:3333) in your browser.
+   - Verify the server responds at [http://localhost:3333/health](http://localhost:3333/health).
+
+## Running Tests
+
+Execute the automated Jasmine tests with Web Test Runner:
+```bash
+npm test
+```
+
+To generate a coverage report, run:
+```bash
+npm run test:coverage
+```
+Coverage output appears in the `coverage/` directory.
+
+## QA Automation
+
+A helper script is provided to build the project and run the test suite with coverage:
+```bash
+npm run qa
+```
+
+Continuous integration runs the same `qa` script for pull requests. See `.github/workflows/qa.yml` for details.
+
+## Offline Testing
+
+After the first visit, the service worker caches assets so the game can run offline. When offline, navigation shows `offline.html`.
+
+---
+Use this document as a quick reference for your QA workflow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # The Dark Room
 
 The Dark Room is a browser-based game built with WebGL and Three.js. It creates a 3D world rendered entirely with text. Originally developed during Global Game Jam 2014, the project lets you explore a "dark room" environment and solve puzzles using keyboard and gamepad controls.
+For testing procedures, see [QA Guide](QA_GUIDE.md).
+
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "scripts": {
     "test": "web-test-runner --config web-test-runner.config.js",
     "start": "node server.js",
+    "test:coverage": "web-test-runner --config web-test-runner.config.js --coverage",
+    "qa": "npm run build && npm run test:coverage",
     "clean": "rimraf dist test/reports",
     "build": "npm run clean && webpack --mode=production",
     "dev": "webpack serve --mode development --hot"


### PR DESCRIPTION
## Summary
- add dedicated QA guide
- link QA guide from main docs
- add QA workflow to run tests with coverage
- ignore coverage directory
- add convenience scripts in package.json

## Testing
- `npm run qa` *(fails: Did not find any tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_68427f66b5b0832881a22bced9bcea74