### PR TITLE
Improve TypeScript typings

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,8 +1,10 @@
 import 'helvetiker';
 
-const app = {};
-
-// The root path to run the application through.
-app.root = "/";
+const app = {
+  // The root path to run the application through.
+  root: "/",
+  // Router instance is attached at runtime from main.ts
+  router: null
+};
 
 export default app;

--- a/app/modules/controllers/controllers.first_person.d.ts
+++ b/app/modules/controllers/controllers.first_person.d.ts
@@ -1,0 +1,2 @@
+declare const controller: any;
+export default controller;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "devDependencies": {
+    "@types/backbone": "^1.4.23",
+    "@types/three": "^0.177.0",
     "@web/test-runner": "^0.20.2",
     "web-test-runner-jasmine": "^0.1.2",
     "@web/test-runner-playwright": "^0.11.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
     "outDir": "dist",
     "baseUrl": "./",
     "paths": {
+      "modules/*": ["app/modules/*"],
+      "app": ["app/app.js"],
+      "app/*": ["app/*"],
       "*": ["*"]
     }
   },


### PR DESCRIPTION
## Summary
- add router field to app object
- add typings for backbone and three
- map path aliases in tsconfig
- stub out typings for first person controller

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Did not find any tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_684292710c6c8328a0ed8f706c583b54