### PR TITLE
Cache bounding boxes for collision checks

### DIFF
--- a/app/modules/controllers/controllers.first_person.js
+++ b/app/modules/controllers/controllers.first_person.js
@@ -180,9 +180,12 @@ console.log('starting lizards')
 //   $('#storyholder_4').show()
 		}
 	}
-	keyboard.addToCollideableObjects = function(o) {
-		this.collideableObjects.push(o);
-	};
+        keyboard.addToCollideableObjects = function(o) {
+                this.collideableObjects.push(o);
+                if (!o.userData) o.userData = {};
+                o.userData.boundingBox = new THREE.Box3().setFromObject(o);
+                o.userData.lastPosition = o.position.clone();
+        };
 
         keyboard.addToDetectableObjects = function(o) {
                 this.detectableObjects.push(o);
@@ -191,7 +194,15 @@ console.log('starting lizards')
         keyboard.collision = function(_mesh) {
                 const playerBox = new THREE.Box3().setFromObject(_mesh);
                 for (const obj of this.collideableObjects) {
-                        const objBox = new THREE.Box3().setFromObject(obj);
+                        if (!obj.userData) obj.userData = {};
+                        if (!obj.userData.boundingBox) {
+                                obj.userData.boundingBox = new THREE.Box3().setFromObject(obj);
+                                obj.userData.lastPosition = obj.position.clone();
+                        } else if (!obj.userData.lastPosition.equals(obj.position)) {
+                                obj.userData.boundingBox.setFromObject(obj);
+                                obj.userData.lastPosition.copy(obj.position);
+                        }
+                        const objBox = obj.userData.boundingBox;
                         if (playerBox.intersectsBox(objBox)) {
                                 if (obj.id === 27) keyboard.enterLevel(27);
                                 else if (obj.id === 30) keyboard.enterLevel(30);

--- a/test/jasmine/specs/controllers/controllers.first_person.spec.js
+++ b/test/jasmine/specs/controllers/controllers.first_person.spec.js
@@ -1,12 +1,24 @@
-define(function(require, exports, module) {
-  "use strict";
+define(function(require) {
+  'use strict';
 
-  var Module = require("modules/controllers/controllers.first_person.js");
+  var THREE = require('three');
+  var keyboard = require('modules/controllers/controllers.first_person.js');
 
-  // Test that the module exists.
-  describe("controllers/controllers.first_person.js", function() {
-    it("exists", function() {
-      expect(Module).toBeTruthy();
+  describe('controllers/controllers.first_person.js', function() {
+    beforeEach(function() {
+      keyboard.collideableObjects = [];
+    });
+
+    it('exists', function() {
+      expect(keyboard).toBeTruthy();
+    });
+
+    it('registers collisions using cached bounding boxes', function() {
+      var player = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1));
+      var obstacle = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1));
+      keyboard.addToCollideableObjects(obstacle);
+      player.position.copy(obstacle.position);
+      expect(keyboard.collision(player)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- cache bounding boxes when adding collideable objects
- reuse cached bounding boxes in the collision check and update only when objects move
- test that cached collision logic still works

## Testing
- `npm test` *(fails: Did not find any tests to run)*
- `CHROME_PATH=/usr/bin/chromium-browser npx web-test-runner "test/jasmine/specs/**/*.spec.js"` *(fails to launch Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68434e99244483289200f8f278e53058