### PR TITLE
Lazy load overlay modules

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -3,10 +3,6 @@ import app from './app.js';
 import Router from './router.js';
 import { initAudioToggle } from './audioToggle.js';
 import { initFullscreenToggle } from './fullscreenToggle.js';
-import { initProgressOverlay } from './progressOverlay.js';
-import { initHelpOverlay } from './helpOverlay.js';
-import { initAdminOverlay } from './adminOverlay';
-import { initSettingsOverlay } from './settingsOverlay.js';
 
 app.router = new Router();
 
@@ -17,9 +13,83 @@ Backbone.history.start({
 
 initAudioToggle();
 initFullscreenToggle();
-initProgressOverlay();
-initHelpOverlay();
-initAdminOverlay();
-initSettingsOverlay();
+
+// Lazily load overlay modules when first requested to reduce initial bundle size
+let progressOverlayLoaded = false;
+let helpOverlayLoaded = false;
+let adminOverlayLoaded = false;
+let settingsOverlayLoaded = false;
+
+async function loadProgressOverlay() {
+  if (!progressOverlayLoaded) {
+    const mod = await import(/* webpackChunkName: "progress-overlay" */ './progressOverlay.js');
+    mod.initProgressOverlay();
+    progressOverlayLoaded = true;
+  }
+}
+
+async function loadHelpOverlay() {
+  if (!helpOverlayLoaded) {
+    const mod = await import(/* webpackChunkName: "help-overlay" */ './helpOverlay.js');
+    mod.initHelpOverlay();
+    helpOverlayLoaded = true;
+  }
+}
+
+async function loadAdminOverlay() {
+  if (!adminOverlayLoaded) {
+    const mod = await import(/* webpackChunkName: "admin-overlay" */ './adminOverlay');
+    mod.initAdminOverlay();
+    adminOverlayLoaded = true;
+  }
+}
+
+async function loadSettingsOverlay() {
+  if (!settingsOverlayLoaded) {
+    const mod = await import(/* webpackChunkName: "settings-overlay" */ './settingsOverlay.js');
+    mod.initSettingsOverlay();
+    settingsOverlayLoaded = true;
+  }
+}
+
+// Set up key listeners to load overlays on demand
+document.addEventListener('keydown', (e) => {
+  switch (e.code) {
+    case 'KeyP':
+      if (!progressOverlayLoaded) {
+        loadProgressOverlay().then(() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyP' }));
+        });
+      }
+      break;
+    case 'KeyH':
+      if (!helpOverlayLoaded) {
+        loadHelpOverlay().then(() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyH' }));
+        });
+      }
+      break;
+    case 'KeyO':
+      if (!adminOverlayLoaded) {
+        loadAdminOverlay().then(() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyO' }));
+        });
+      }
+      break;
+    case 'Escape':
+      if (!settingsOverlayLoaded) {
+        loadSettingsOverlay().then(() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Escape' }));
+        });
+      }
+      break;
+  }
+});
+
+// Hint browsers to prefetch overlay bundles after initial load
+import(/* webpackPrefetch: true */ './progressOverlay.js');
+import(/* webpackPrefetch: true */ './helpOverlay.js');
+import(/* webpackPrefetch: true */ './adminOverlay');
+import(/* webpackPrefetch: true */ './settingsOverlay.js');
 
 export default app;


### PR DESCRIPTION
## Summary
- defer loading of overlay modules until they are first used
- prefetch overlay bundles for quicker activation

## Testing
- `npm test` *(fails: Did not find any tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_6844e809faa88328833d69b8355caaa4