### PR TITLE
Add memory match puzzle

### DIFF
--- a/app/modules/controllers/controllers.first_person.js
+++ b/app/modules/controllers/controllers.first_person.js
@@ -7,6 +7,7 @@ import * as THREE from 'three';
 import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
 import story from 'modules/story/story.main';
 import createMagicSquare from 'modules/puzzles/magic_square';
+import createMemoryMatch from 'modules/puzzles/memory_match';
 import { markPuzzleSolved, markItemCollected, markLevelVisited, setCurrentLevel } from '../../progress';
 import { highlight, removeHighlight } from '../../highlightManager.js';
 import { initTouchControls, getMove, getLook } from '../../touchControls.js';
@@ -44,6 +45,10 @@ keyboard.initPointerLock = function(camera) {
 document.addEventListener('keydown', (e) => {
   if (e.code === 'KeyO') {
     createMagicSquare(() => {
+      markPuzzleSolved();
+    });
+  } else if (e.code === 'KeyN') {
+    createMemoryMatch(() => {
       markPuzzleSolved();
     });
   }

--- a/app/modules/puzzles/memory_match.js
+++ b/app/modules/puzzles/memory_match.js
@@ -1,0 +1,105 @@
+import { startPuzzle } from '../../progress';
+
+export default function createMemoryMatch(onSolved) {
+  startPuzzle();
+  let startTime = Date.now();
+  const letters = 'ABCDEFGH'.split('');
+  let cards = shuffle(letters.concat(letters));
+  let revealed = [];
+  let matched = new Set();
+  let firstPick = null;
+
+  const container = document.createElement('div');
+  container.id = 'memoryMatch';
+
+  const timerEl = document.createElement('div');
+  timerEl.id = 'puzzleTimer';
+  container.appendChild(timerEl);
+
+  const grid = document.createElement('div');
+  grid.id = 'memoryGrid';
+  container.appendChild(grid);
+
+  const restartBtn = document.createElement('button');
+  restartBtn.id = 'restartPuzzle';
+  restartBtn.textContent = 'Restart';
+  restartBtn.addEventListener('click', restart);
+  container.appendChild(restartBtn);
+
+  document.body.appendChild(container);
+
+  renderGrid();
+  updateTimer(startTime);
+
+  function updateTimer(start) {
+    const now = Date.now();
+    timerEl.textContent = ((now - start) / 1000).toFixed(1) + 's';
+    if (!container.classList.contains('solved')) {
+      requestAnimationFrame(() => updateTimer(start));
+    }
+  }
+
+  function renderGrid() {
+    grid.innerHTML = '';
+    cards.forEach((letter, idx) => {
+      const card = document.createElement('div');
+      card.className = 'memory-card';
+      card.dataset.index = idx;
+      card.textContent = revealed.includes(idx) ? letter : '?';
+      card.addEventListener('click', () => onCardClick(idx));
+      grid.appendChild(card);
+    });
+  }
+
+  function onCardClick(index) {
+    if (revealed.includes(index) || container.classList.contains('solved')) return;
+    revealed.push(index);
+    if (firstPick === null) {
+      firstPick = index;
+    } else {
+      if (cards[firstPick] === cards[index]) {
+        matched.add(cards[index]);
+        firstPick = null;
+        if (matched.size === letters.length) solved();
+      } else {
+        const a = firstPick;
+        const b = index;
+        setTimeout(() => {
+          revealed = revealed.filter(i => i !== a && i !== b);
+          firstPick = null;
+          renderGrid();
+        }, 600);
+      }
+    }
+    renderGrid();
+  }
+
+  function solved() {
+    container.classList.add('solved');
+    if (typeof onSolved === 'function') onSolved();
+    setTimeout(() => {
+      container.remove();
+    }, 1000);
+  }
+
+  function restart() {
+    container.classList.remove('solved');
+    startPuzzle();
+    startTime = Date.now();
+    cards = shuffle(letters.concat(letters));
+    revealed = [];
+    matched.clear();
+    firstPick = null;
+    renderGrid();
+    updateTimer(startTime);
+  }
+
+  function shuffle(arr) {
+    const a = arr.slice();
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  }
+}

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -193,6 +193,40 @@ font-family: 'Bazar', sans-serif;
   }
 }
 
+/* Memory Match puzzle */
+#memoryMatch {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.8);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#memoryGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 40px);
+  gap: 5px;
+}
+
+.memory-card {
+  width: 40px;
+  height: 40px;
+  background: #222;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+#memoryMatch.solved {
+  animation: fadeOut 1s forwards;
+}
+
 #progressOverlay {
   position: absolute;
   top: 10px;


### PR DESCRIPTION
## Summary
- add a new Memory Match puzzle module
- style the puzzle
- allow launching either Magic Square (O key) or Memory Match (N key)

## Testing
- `npm test` *(fails: Did not find any tests to run)*
- `npx playwright install chromium` *(fails: download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68455a9626f88328be8f85f3f95fca88