### PR TITLE
Update docs and add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The Dark Room is a WebGL world rendered entirely with text. It places players in
 For an in-depth guide covering installation, controls, and offline support, see
 [the documentation](docs/README.md).
 For QA setup instructions, see [the QA guide](docs/QA_GUIDE.md).
+For a high-level overview of how the pieces fit together, see the
+[architecture document](docs/ARCHITECTURE.md).
 
 
 ![alt tag](http://i.imgur.com/BTIl5zC.png)
@@ -38,7 +40,7 @@ Press **R** during a puzzle to quickly restart your attempt.
 
 ## Local Development
 
-Ensure you have **Node.js v18 or later** installed.
+Ensure you have **Node.js v20 or later** installed.
 
 1. Install dependencies and build the bundle using webpack:
    ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,18 @@
+# Architecture Overview
+
+The diagram below illustrates the flow of data within the game.
+
+```
++-----------------+     +------------------+
+|  WebGL Renderer |<--> |    Game Logic    |
++-----------------+     +------------------+
+        ^                       |
+        |                       v
++-----------------+     +------------------+
+|  ServiceWorker  |<--> | Cached Resources |
++-----------------+     +------------------+
+```
+
+The WebGL renderer draws the text-based world and communicates with the core
+game logic. A service worker sits between the browser and network requests to
+cache assets so the game runs offline after the first visit.

--- a/docs/QA_GUIDE.md
+++ b/docs/QA_GUIDE.md
@@ -4,7 +4,7 @@ This guide outlines how to set up and test **The Dark Room** locally.
 
 ## Prerequisites
 
-- **Node.js v18 or later**
+- **Node.js v20 or later**
 - A modern web browser (Chrome, Firefox, or Edge)
 
 ## Getting Started

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ For testing procedures, see [QA Guide](QA_GUIDE.md).
 
 ## Installation
 
-1. Install Node.js (v18 or later recommended).
+1. Install Node.js (v20 or later recommended).
 2. Run `npm install` to install dependencies.
 3. Build the project:
    ```bash
@@ -99,4 +99,6 @@ Contributions are welcome! Feel free to submit issues or pull requests. Please r
 
 - [Live Demo](http://the-dark-room-game.herokuapp.com)
 - [Global Game Jam 2014](https://globalgamejam.org/) – the event where the project originated.
+- [Architecture Diagram](ARCHITECTURE.md) – high-level view of the game
+  structure and offline flow.
 


### PR DESCRIPTION
## Summary
- mention architecture doc in README
- bump Node.js requirement to v20
- add ASCII architecture diagram
- document link to diagram

## Testing
- `npm test` *(fails: Did not find any tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_6846780b06d48328ab9d4285cf204eaa