### PR TITLE
Fix typo in darkroom door test

### DIFF
--- a/test/jasmine/specs/meshes/meshes.darkroom.door.spec.js
+++ b/test/jasmine/specs/meshes/meshes.darkroom.door.spec.js
@@ -1,10 +1,10 @@
 define(function(require, exports, module) {
   "use strict";
 
-  var Module = require("modules/meshes/meshes.darkdroom.door");
+  var Module = require("modules/meshes/meshes.darkroom.door");
 
   // Test that the module exists.
-  describe("meshes/meshes.darkdroom.door", function() {
+  describe("meshes/meshes.darkroom.door", function() {
     it("exists", function() {
       expect(Module).toBeTruthy();
     });


### PR DESCRIPTION
## Summary
- rename incorrectly named test file
- update require path in the test

## Testing
- `npm test` *(fails: Did not find any tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_68467e2c6420832899c6cdecbeede519